### PR TITLE
Changes for dplyr 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,8 @@ Description: Supports systematic scrutiny, modification, and integration of
     and informative() drops columns in x that are entirely NA; constant() returns
     values that are constant, given a key.  Data that have defined unique 
     combinations of grouping values behave more predictably during merge operations.
+URL: https://github.com/bergsmat/wrangle
+BugReports: https://github.com/bergsmat/wrangle/issues
 License: GPL-3
 LazyData: TRUE
 Imports:

--- a/R/wrangle.R
+++ b/R/wrangle.R
@@ -143,7 +143,7 @@ key.grouped_df <- function(x,...)sapply(groups(x),as.character)
 # @describeIn wrangle
 
 unsorted.grouped_df <- function(x,...){
-  x$original_ <- seq_len(nrow(x))
+  x$original_ <- as.numeric(seq_len(nrow(x)))
   x$leads_ <- lead(x$original_,default=Inf)
   x$lags_ <- lag(x$original_,default=-Inf)
   x %<>% sort


### PR DESCRIPTION
Because of how dplyr 1.0.0 implements `lead()` and `lag()`, `unsorted.grouped_df()` fails now, root reason:

``` r
library(dplyr, warn.conflicts = FALSE)
lead(1:2, default = Inf)
#> Error: Can't convert from `default` <double> to `x` <integer> due to loss of precision.
#> * Locations: 1
```

<sup>Created on 2020-05-04 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This would fix the checks for package `nonmemica`, which currently fails. 

